### PR TITLE
Optimized admin overview page for devices under 768px width

### DIFF
--- a/src/apps/admin/pages/Overview.scss
+++ b/src/apps/admin/pages/Overview.scss
@@ -58,7 +58,7 @@
 }
 .song-rec {
   @include font-body('sm');
-  color: var(--color-label);
+  color: #818181;
 }
 
 .curr-song {
@@ -90,4 +90,45 @@
 
 ::-webkit-scrollbar-thumb:hover {
   background: #8f8f8f;
+}
+
+@media (max-width: 768px) {
+  .disk {
+    display: flex;
+    width: 8vh;
+    height: 8vh;
+    margin-right: 10rem;
+    margin-top: 5rem;
+  }
+
+  .card {
+    transform: translate(0, 0);
+    width: 90%;
+  }
+
+  .song-queue {
+    padding: 1.5rem;
+    margin-top: -3rem;
+  }
+
+  .curr-song {
+    width: 20vh;
+    height: 20vh;
+  }
+}
+
+@media (max-width: 480px) {
+  .card {
+    width: 90%;
+  }
+
+  .song-queue {
+    padding: 1rem;
+    margin-top: -3rem;
+  }
+
+  .curr-song {
+    width: 15vh;
+    height: 15vh;
+  }
 }


### PR DESCRIPTION
**Changes Made**
Responsive Layout Adjustments:
Updated .disk to have a flex display with a fixed size (8vh x 8vh) and adjusted margins for better positioning on smaller screens (max-width: 768px).

Card Component Enhancements:
Adjusted .card width to 90% for better adaptability on smaller screens (max-width: 768px and max-width: 480px).
Ensured .card remains centered by resetting transform to translate(0,0).

Song Queue Improvements:
Modified .song-queue padding (1.5rem for max-width: 768px, 1rem for max-width: 480px) to optimize spacing.
Adjusted .song-queue margin-top to -3rem for a more compact display on smaller screens.

Current Song Display Adjustments:
Reduced .curr-song size to 20vh x 20vh for max-width: 768px and further to 15vh x 15vh for max-width: 480px to maintain proportionality on smaller screens.