### PR TITLE
fixed allignment issues with TrackItems (issue)

### DIFF
--- a/src/components/track-list/TrackItem.scss
+++ b/src/components/track-list/TrackItem.scss
@@ -49,9 +49,14 @@
     gap: 5px;
   }
   &__rec-by {
-    flex: $flex-g-s 30%;
+    flex: $flex-g-s 20%;
   }
   &__duration {
+    flex: $flex-g-s 8%;
+  }
+  &__activity {
+    display: flexbox;
     flex: $flex-g-s 15%;
+    justify-content: right;
   }
 }


### PR DESCRIPTION
Fixed allignment issues with TrackItems from this issue: 
[https://github.com/ufosc/Jukebox-Frontend/issues/150](https://github.com/ufosc/Jukebox-Frontend/issues/150)

![image](https://github.com/user-attachments/assets/0a8ea3cf-c78d-4a32-97d6-a168e335a845)
