### PR TITLE
Feat: Designed and implemented a new standardized admin header component

### DIFF
--- a/src/apps/admin/components/AdminHeader.scss
+++ b/src/apps/admin/components/AdminHeader.scss
@@ -1,0 +1,147 @@
+.page-title-style {
+  @include font-headline('sm');
+}
+
+.adminheader-style {
+  margin-bottom: 5rem;
+  display: flex;
+  flex-direction: column;
+  padding: 4rem 4rem 0rem 0rem;
+  gap: 3rem;
+}
+
+.theme--dark .adminheader-style {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.theme--light .adminheader-style {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.4);
+}
+
+.pageheader-style {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.breadcrumb-style {
+  font-size: smaller;
+}
+
+.theme--dark .breadcrumb-style {
+  color: rgba(255, 255, 255, 0.7);
+}
+.theme--light .breadcrumb-style {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+// top right bottom left
+
+.page-title-style {
+  font-size: xx-large;
+  font-weight: bold;
+}
+
+.link-style {
+  padding: 1rem;
+  border-radius: 2rem;
+  color: white;
+  background-color: #214245;
+}
+
+.options-container {
+  display: flex;
+}
+
+.music-link-style,
+.cta-style {
+  font-size: small;
+  letter-spacing: -0.05rem;
+  color: inherit;
+  justify-content: space-between;
+  display: flex;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  border-radius: 0.2rem;
+  border-bottom: 3px solid transparent;
+}
+
+.music-link-style:hover,
+.cta-style:hover {
+  background-color: rgba(195, 192, 192, 0.5);
+}
+
+.music-link-style:active,
+.music-link-style:focus,
+.music-link-style:focus-visible,
+.cta-style:active,
+.cta-style:focus,
+.cta-style:focus-visible,
+.music-link-style.active, // Add active state styles
+.cta-style.active {
+  border-bottom: 3px solid #9c4730;
+  border-radius: 0.2rem;
+}
+
+.options {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  color: inherit;
+  background-color: transparent;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  border-radius: 0.5rem;
+  transition:
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.theme--dark .options:hover {
+  background-color: rgba(90, 90, 90, 0.2);
+}
+
+.theme--light .options:hover {
+  background-color: rgba(90, 90, 90, 0.2);
+}
+
+.theme--dark .options {
+  border: 0.2px solid #565656;
+}
+
+.theme--light .options {
+  border: 0.2px solid rgba(225, 225, 225);
+}
+
+.theme--dark .options:active,
+.options:focus {
+  border: 0.2px solid transparent;
+  box-shadow: 0 0 0 2px rgb(255, 255, 255);
+}
+
+.theme--light .options:active,
+.options:focus {
+  border: 0.2px solid transparent;
+  box-shadow: 0 0 0 2px #565656;
+}
+
+.dropdown-container {
+  display: flex;
+  flex-direction: column;
+  width: 20rem;
+  position: relative;
+}
+
+.dropdown {
+  position: absolute; /* because content shifts around when dropdown is open*/
+  top: 100%;
+  left: 0;
+  z-index: 10;
+  width: 100%;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border: 0.2px solid #565656;
+  border-radius: 0.5rem;
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+}

--- a/src/apps/admin/components/AdminHeader.tsx
+++ b/src/apps/admin/components/AdminHeader.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import './AdminHeader.scss'
+
+interface HeaderProps {
+  title: string
+  children?: ReactNode
+  cta?: CtaBtn[]
+  music?: boolean
+}
+
+interface CtaBtn {
+  label: string
+  link: string
+}
+
+export const AdminHeader = ({ title, cta, music, children }: HeaderProps) => {
+  const location = useLocation()
+  const currentPath = location.pathname
+
+  return (
+    <div className="adminheader-style">
+      <div className="pageheader-style">
+        <p className="breadcrumb-style">Admin/{title}</p>
+        <p className="page-title-style">{title}</p>
+      </div>
+      <div className="options-container">
+        {cta &&
+          cta.map((button, index) => (
+            <Link
+              key={index}
+              className={`cta-style ${currentPath === button.link ? 'active' : ''}`}
+              to={button.link}
+            >
+              {button.label}
+            </Link>
+          ))}
+        {music && (
+          <Link
+            className={`music-link-style ${currentPath === '/admin/music/queue' ? 'active' : ''}`}
+            to="/admin/music/queue"
+          >
+            Track Queue
+          </Link>
+        )}
+        {music && (
+          <Link
+            className={`music-link-style ${currentPath === '/admin/music/search' ? 'active' : ''}`}
+            to="/admin/music/search"
+          >
+            Search Tracks
+          </Link>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
**Overview**
As requested in issue #148 , I have standardized the design for headers on all admin pages except for overview. Additionally, there are options beneath the header that may be passed in to the header component if appropriate for a specific page. Examples of these props are listed below.

**Example 1**
For the Music.tsx page, if the prop "music={true}" is passed into admin header component, two call-to-action (cta) buttons will be rendered: Track Queue and Search Tracks. Cta buttons have been nicely styled and takes inspiration from Github's header component.

**Example 2**
If a page requires a more generalized cta button, one can pass in an object to the prop cta. This object is structured as a label and a link. As shown below, the label represents the name for the button that will be displayed and the link refers to the path of the page the button redirects to.

![image](https://github.com/user-attachments/assets/f3f1c457-79ae-47e1-aaa7-37c61175a4ee)

**Final result**
Before:
![image](https://github.com/user-attachments/assets/c6fa7063-464a-409e-a7e8-688a5c3a9bd4)
After:
![image](https://github.com/user-attachments/assets/cd597b8f-89ce-487e-9dec-d9069236f3f9)

